### PR TITLE
Fix BIN2ISO only processing the first found BIN file

### DIFF
--- a/PFS-BatchKit-Manager/!PFS-BatchKit-Manager.bat
+++ b/PFS-BatchKit-Manager/!PFS-BatchKit-Manager.bat
@@ -12152,8 +12152,8 @@ echo Converting... .BIN To .ISO
 "%~dp0BAT\bchunk" "!fname!.bin" "!fname!.cue" "!fname!" >nul 2>&1 
 move "!fname!01.iso" "!fname!.iso" >nul 2>&1
 
-move *.bin "%~dp0CD\Original" >nul 2>&1
-move *.cue "%~dp0CD\Original" >nul 2>&1
+move "!fname!.bin" "%~dp0CD\Original" >nul 2>&1
+move "!fname!.cue" "%~dp0CD\Original" >nul 2>&1
  endlocal
 endlocal
 )


### PR DESCRIPTION
Noticed that the "Convert .BIN to .ISO" only converted the first found `.bin` file, because once it had done that it just moved all `*.bin` and `*.cue` files to the `Original` directory. I assumed it was meant to loop through and process them all because of the `for %%f in (*.bin)` loop, so I patched it to only move the converted `*.bin` and `*.cue` files at the end of the loop instead.